### PR TITLE
Merge config and secret values before rendering secrets template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Merge config and secret values before rendering secret template.
+
 ## [0.3.2] - 2021-05-28
 
 ### Fixed

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -92,11 +92,11 @@ func New(config Config) (*Generator, error) {
 //    of 3.) app overrides
 // 5. Get installation-specific secret template data and decrypt it
 // 6. Merge config and secret values before templating app secret
-// 6. Get global secret template for the app (if available) and render it with
+// 7. Get global secret template for the app (if available) and render it with
 //    installation secret template data (result of 5.)
-// 7. Get installation-specific secret template patch (if available) and
+// 8. Get installation-specific secret template patch (if available) and
 //    decrypt it
-// 8. Patch secret template (result of 6.) with decrypted patch values (result
+// 9. Patch secret template (result of 6.) with decrypted patch values (result
 //    of 7.)
 func (g Generator) generateRawConfig(ctx context.Context, app string) (configmap string, secret string, err error) {
 	// 1.

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -91,6 +91,7 @@ func New(config Config) (*Generator, error) {
 // 4. Patch global template (result of 2.) with installation-specific (result
 //    of 3.) app overrides
 // 5. Get installation-specific secret template data and decrypt it
+// 6. Merge config and secret values before templating app secret
 // 6. Get global secret template for the app (if available) and render it with
 //    installation secret template data (result of 5.)
 // 7. Get installation-specific secret template patch (if available) and
@@ -178,6 +179,8 @@ func (g Generator) generateRawConfig(ctx context.Context, app string) (configmap
 		return "", "", microerror.Mask(err)
 	}
 	g.logMessage(ctx, "merged config and secret values")
+
+	fmt.Println("here")
 
 	// 7.
 	secretTemplate, err := g.getWithPatchIfExists(


### PR DESCRIPTION
Without this it is not possible to use config data in secret templates (e.g. check provider.kind)

## Checklist

- [x] Update changelog in CHANGELOG.md.

