### PR TITLE
Push image to docker hub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,19 @@ workflows:
 
       - architect/push-to-docker:
           context: "architect"
+          name: push-konfigure-to-docker
+          image: "quay.io/giantswarm/konfigure"
+          username_envar: "DOCKER_USERNAME"
+          password_envar: "DOCKER_PASSWORD"
+          requires:
+            - go-build
+          # Needed to trigger job also on git tag.
+          filters:
+            tags:
+              only: /^v.*/
+
+      - architect/push-to-docker:
+          context: "architect"
           name: push-konfigure-to-quay
           image: "quay.io/giantswarm/konfigure"
           username_envar: "QUAY_USERNAME"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ workflows:
       - architect/push-to-docker:
           context: "architect"
           name: push-konfigure-to-docker
-          image: "quay.io/giantswarm/konfigure"
+          image: "docker.io/giantswarm/konfigure"
           username_envar: "DOCKER_USERNAME"
           password_envar: "DOCKER_PASSWORD"
           requires:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Push image to docker hub as this is the registry we use in
+management-clusters-fleet.
+
 ## [0.5.5] - 2022-02-21
 
 ### Fixed


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/20983

So we are less reliant on `crsync` this pushes the image to docker hub. 

This is the registry we use in management-clusters-fleet and if the sync fails we get paged for all MCs.

## Checklist

- [x] Update changelog in CHANGELOG.md.
