### PR TITLE
Log file paths in error messages so that flux logs tell us exactly where something went wrong

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Log file paths in error messages so that flux logs tell us exactly where something went wrong
+
 ## [0.14.4] - 2023-04-06
 
 ## [0.14.3] - 2023-01-11
@@ -14,8 +18,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix where git command is run in `konfigure generate` command.
-
-## [0.14.2] - 2022-11-15
 
 ### Changed
 

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/hashicorp/vault/api v1.8.2
 	github.com/imdario/mergo v0.3.13
+	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.6.1
 	go.mozilla.org/sops/v3 v3.7.3
 	go.uber.org/config v1.4.0
@@ -123,7 +124,6 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/oklog/run v1.1.0 // indirect
 	github.com/pierrec/lz4 v2.6.1+incompatible // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.12.2 // indirect
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.32.1 // indirect

--- a/pkg/generator/error.go
+++ b/pkg/generator/error.go
@@ -28,12 +28,3 @@ func IsNotFound(err error) bool {
 
 	return microerror.Cause(err) == notFoundError
 }
-
-var failedToDecryptError = &microerror.Error{
-	Kind: "failedToDecryptError",
-}
-
-// IsFailedToDecryptError asserts failedToDecryptError.
-func IsFailedToDecryptError(err error) bool {
-	return microerror.Cause(err) == failedToDecryptError
-}


### PR DESCRIPTION
This would be a huge quality-of-life improvement.

Seeing an error like this on a flux `Kustomization` is already frustratingly useless:

```
kustomize build failed: couldn't execute function: MalformedYAMLError: yaml: line 19: could not find expected ':'
```

But at least, flux logs show something more:

```
2023-08-29T13:49:41.630088191+02:00 {"level":"error","ts":"2023-08-29T11:49:41.629Z","msg":"Reconciliation failed after 2.136607427s, next try in 1m0s","controller":"kustomization","controllerGroup":"kustomize.toolkit.fluxcd.io","controllerKind":"Kustomization","Kustomization":{"name":"collection","namespace":"flux-giantswarm"},"namespace":"flux-giantswarm","name":"collection","reconcileID":"ce21dac0-aac5-4327-afe6-290ab4568796","revision":"master@sha1:1a05d2d785d719692957340f60c2a99081dbd630","error":"kustomize build failed: couldn't execute function: MalformedYAMLError: yaml: line 19: could not find expected ':'"}
[...]
2023-08-29T13:52:16.096864972+02:00 processing filter: failed to decrypt error: Failed to decrypt secret, root cause: "Failed to verify data integrity. expected mac \"8387CB499C6EC6CA4EE88C1122E62BFBDC1376D8CC1FAB621C2FBAD6442E63814ED8948E18BC3098A8344742826FD247306B460DAA41746A43C8CDB367D7071A\", got \"8D85E64502BE0AFF5DF1CCE99A6FE764EF119B96BB505A94ACF943FA601725DF0523F98B33645B0E6D11804751BD4AA13330DB9B709CBB0F9D36137C7D9EA095\""Error: Failed to decrypt: Failed to decrypt secret, root cause: "Failed to verify data integrity. expected mac \"8387CB499C6EC6CA4EE88C1122E62BFBDC1376D8CC1FAB621C2FBAD6442E63814ED8948E18BC3098A8344742826FD247306B460DAA41746A43C8CDB367D7071A\", got \"8D85E64502BE0AFF5DF1CCE99A6FE764EF119B96BB505A94ACF943FA601725DF0523F98B33645B0E6D11804751BD4AA13330DB9B709CBB0F9D36137C7D9EA095\""
```

Typically, that error leads us to fixing the issue, but unfortunately `konfigure` logs don't tell us which SOPS secret file (in the above example logs) is problematic. Hence, I'd like to log the file which couldn't be loaded.

Tested locally and it looks like this with my changes:

```
$ cd config

$ konfigure generate --raw --app-name teleport-operator --installation golem
Error: Failed to decrypt app secret in "installations/golem/apps/teleport-operator/secret-values.yaml.patch": Failed to verify data integrity. expected mac "8387CB499C6EC6CA4EE88C1122E62BFBDC1376D8CC1FAB621C2FBAD6442E63814ED8948E18BC3098A8344742826FD247306B460DAA41746A43C8CDB367D7071A", got "8D85E64502BE0AFF5DF1CCE99A6FE764EF119B96BB505A94ACF943FA601725DF0523F98B33645B0E6D11804751BD4AA13330DB9B709CBB0F9D36137C7D9EA095"
	/path/to/konfigure/pkg/generator/generator.go:266
	/path/to/konfigure/pkg/generator/generator.go:91
	/path/to/konfigure/pkg/generator/generator.go:353
	/path/to/konfigure/internal/generator/service.go:184
	/path/to/konfigure/cmd/generate/runner.go:110
	/path/to/konfigure/cmd/generate/runner.go:46
	/path/to/konfigure/main.go:125
	/path/to/konfigure/main.go:26
```

## Checklist

- [x] Update changelog in CHANGELOG.md.
