### PR TITLE
Updating konfigure for GitRepository include feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Use `Last-Modified` header as indicator the archive has changed.
+
 ## [0.16.0] - 2024-02-20
 
 ### Added


### PR DESCRIPTION
## Description

Using include feature of GitRepository may lead to the situation the archive is rebuilt under the same revision number, and hence URL, as a result of included repository (shared-configs) being updated and base repository (customer-configs) staying the same. In such case the current cache building logic won't spot the change and hence won't refresh the cache, so the idea is to enhance it by using the `Last-Modified` header.

## Checklist

- [x] Update changelog in CHANGELOG.md.
