### PR TITLE
fix(ci): use arch-specific binary in Dockerfile for multiarch builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM gsoci.azurecr.io/giantswarm/alpine:3.23.3
 
+ARG TARGETARCH
+
 RUN apk add --no-cache ca-certificates
 
-ADD ./konfigure /konfigure
+COPY ./konfigure-linux-${TARGETARCH} /konfigure
 
 ENTRYPOINT ["/konfigure"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM gsoci.azurecr.io/giantswarm/alpine:3.23.3
 
 ARG TARGETARCH
 
-RUN apk add --no-cache ca-certificates=20260413-r0
+# hadolint ignore=DL3018
+RUN apk add --no-cache ca-certificates
 
 COPY ./konfigure-linux-${TARGETARCH} /konfigure
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM gsoci.azurecr.io/giantswarm/alpine:3.23.3
 
 ARG TARGETARCH
 
+# ca-certificates is intentionally unpinned: pinning would freeze the Mozilla trust store,
+# preventing revoked or removed CAs from being dropped on rebuild.
 # hadolint ignore=DL3018
 RUN apk add --no-cache ca-certificates
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM gsoci.azurecr.io/giantswarm/alpine:3.23.3
 
 ARG TARGETARCH
 
-RUN apk add --no-cache ca-certificates
+RUN apk add --no-cache ca-certificates=20260413-r0
 
 COPY ./konfigure-linux-${TARGETARCH} /konfigure
 


### PR DESCRIPTION
## What

Fixes the Dockerfile to copy the arch-specific binary produced by \`architect/go-build\` instead of the linux/amd64-only backward-compatibility copy.

\`architect/go-build\` produces \`<binary>-linux-amd64\` and \`<binary>-linux-arm64\` (plus a \`<binary>\` compat copy for linux/amd64 only). With \`platforms: "linux/amd64,linux/arm64"\` in \`push-to-registries\`, buildx runs the Dockerfile for each platform — the arm64 build was silently getting the amd64 binary from the compat copy.

Adding \`ARG TARGETARCH\` and using \`<binary>-linux-\${TARGETARCH}\` ensures each platform build picks up the correct binary.

Followup to the orb 9.1.0 / multiarch release PR merged earlier today.